### PR TITLE
Make fields nullable that actually can be null

### DIFF
--- a/src/Model/Campaign/Campaign.php
+++ b/src/Model/Campaign/Campaign.php
@@ -9,7 +9,7 @@ class Campaign extends AbstractData
 	/**
 	 * AB Split-specific options for a campaign.
 	 */
-	public ABSplitOptions $abSplitOpts;
+	public ?ABSplitOptions $abSplitOpts = null;
 	/**
 	 * The link to the campaign's archive version.
 	 * Example: http://eepurl.com/bsOxxx.
@@ -50,11 +50,11 @@ class Campaign extends AbstractData
 	/**
 	 * For sent campaigns, a summary of opens, clicks, and unsubscribes.
 	 */
-	public CampaignReportSummary $reportSummary;
+	public ?CampaignReportSummary $reportSummary = null;
 	/**
 	 * RSS-specific options for a campaign.
 	 */
-	public RSSOptions $rssOpts;
+	public ?RSSOptions $rssOpts = null;
 	/**
 	 * The time and date a campaign was sent.
 	 * Example: 2015-07-09T13:14:28+00:00.
@@ -64,7 +64,7 @@ class Campaign extends AbstractData
 	/**
 	 * The preview for the campaign as rendered by social networks like Facebook and Twitter.
 	 */
-	public CampaignSocialCard $socialCard;
+	public ?CampaignSocialCard $socialCard = null;
 	/**
 	 * The current status of the campaign ('save', 'paused', 'schedule', 'sending', 'sent').
 	 * Example: save.
@@ -82,7 +82,7 @@ class Campaign extends AbstractData
 	/**
 	 * The settings specific to A/B test campaigns.
 	 */
-	public ABTestOptions $variateSettings;
+	public ?ABTestOptions $variateSettings = null;
 	protected array $classMap = [
 		'recipients' => CampaignList::class,
 		'settings' => CampaignSettings::class,

--- a/src/Model/Campaign/CampaignDeliveryStatus.php
+++ b/src/Model/Campaign/CampaignDeliveryStatus.php
@@ -10,16 +10,16 @@ class CampaignDeliveryStatus extends AbstractData
 	 * Whether a campaign send can be canceled.
 	 * Example: 1.
 	 */
-	public bool $canCancel;
+	public ?bool $canCancel = null;
 	/**
 	 * The total number of emails canceled for this campaign.
 	 */
-	public int $emailsCanceled;
+	public ?int $emailsCanceled = null;
 	/**
 	 * The total number of emails confirmed sent for this campaign so far.
 	 * Example: 42.
 	 */
-	public int $emailsSent;
+	public ?int $emailsSent = null;
 	/**
 	 * Whether Campaign Delivery Status is enabled for this account and campaign.
 	 * Example: 1.
@@ -29,5 +29,5 @@ class CampaignDeliveryStatus extends AbstractData
 	 * The current state of a campaign delivery.
 	 * Example: canceling.
 	 */
-	public string $status;
+	public ?string $status = null;
 }

--- a/src/Model/Campaign/CampaignList.php
+++ b/src/Model/Campaign/CampaignList.php
@@ -23,7 +23,7 @@ class CampaignList extends AbstractData
 	/**
 	 * Segment options.
 	 */
-	public SegmentOptions $segmentOpts;
+	public ?SegmentOptions $segmentOpts = null;
 	/**
 	 * A string marked-up with HTML explaining the segment used for the campaign in plain English.
 	 */

--- a/src/Model/Campaign/CampaignSettings.php
+++ b/src/Model/Campaign/CampaignSettings.php
@@ -16,7 +16,7 @@ class CampaignSettings extends AbstractData
 	 *
 	 * @var string[]
 	 */
-	public array $autoFbPost;
+	public ?array $autoFbPost = null;
 	/**
 	 * Automatically append MailChimp's default footer to the campaign.
 	 * Example: 1.
@@ -45,7 +45,7 @@ class CampaignSettings extends AbstractData
 	 * The 'from' name on the campaign (not an email address).
 	 * Example: Urist McVankab.
 	 */
-	public string $fromName;
+	public ?string $fromName = null;
 	/**
 	 * Automatically inline the CSS included with the campaign content.
 	 * Example: 1.
@@ -55,12 +55,12 @@ class CampaignSettings extends AbstractData
 	 * The reply-to email address for the campaign.
 	 * Example: urist.mcvankab@freddiesjokes.com.
 	 */
-	public string $replyTo;
+	public ?string $replyTo = null;
 	/**
 	 * The subject line for the campaign.
 	 * Example: Freddie Likes Jokes.
 	 */
-	public string $subjectLine;
+	public ?string $subjectLine = null;
 	/**
 	 * The id for the template used in this campaign.
 	 * Example: 9001.

--- a/src/Model/Campaign/CampaignTrackingOptions.php
+++ b/src/Model/Campaign/CampaignTrackingOptions.php
@@ -11,7 +11,7 @@ class CampaignTrackingOptions extends AbstractData
 	/**
 	 * Capsule tracking options for a campaign. Must be using MailChimp's built-in Capsule integration.
 	 */
-	public CapsuleCRMTracking $capsule;
+	public ?CapsuleCRMTracking $capsule = null;
 	/**
 	 * The custom slug for ClickTale Analytics tracking (max of 50 bytes).
 	 * Example: Freddies_Jokes_2015_07_07.
@@ -44,7 +44,7 @@ class CampaignTrackingOptions extends AbstractData
 	/**
 	 * Salesforce tracking options for a campaign.  Must be using MailChimp's built-in Salesforce integration.
 	 */
-	public SalesforceCRMTracking $salesforce;
+	public ?SalesforceCRMTracking $salesforce = null;
 	/**
 	 * Whether to track clicks in the plain-text version of the campaign. Defaults to 'true'.
 	 * Example: 1.


### PR DESCRIPTION
When saving campaign fails some fields are nullable even thought the documentation says so.